### PR TITLE
Remove references to the legacy api email parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ This is an SDK for the [dehashed](https://dehashed.com/) api.
 ```rs
 use dehashed_rs::*;
 
-let email = "test@example.com".to_string();
 let api_key = "<api_key>".to_string();
 
 // Create an api instance
-let api = DehashedApi::new(email, api_key).unwrap();
+let api = DehashedApi::new(api_key).unwrap();
 
 // Query for the domain example.com
 if let Ok(res) = api
@@ -34,11 +33,10 @@ away the need to manage get past the rate limit:
 use dehashed_rs::*;
 use tokio::sync::oneshot;
 
-let email = "test@example.com".to_string();
 let api_key = "<api_key>".to_string();
 
 // Create an api instance
-let api = DehashedApi::new(email, api_key).unwrap();
+let api = DehashedApi::new(api_key).unwrap();
 // Create the scheduler
 let scheduler = api.start_scheduler();
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -142,7 +142,6 @@ impl DehashedApi {
     /// Create a new instance of the SDK.
     ///
     /// **Parameter**:
-    /// - `email`: The mail address that is used for authentication
     /// - `api_key`: The api key for your account (found on your profile page)
     ///
     /// This method fails if the [Client] could not be constructed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! ```rust
 //! use dehashed_rs::*;
 //! # tokio_test::block_on(async {
-//! let email = "test@example.com".to_string();
 //! let api_key = "<api_key>".to_string();
 //!
 //! // Create an api instance
@@ -33,7 +32,6 @@
 //! use dehashed_rs::*;
 //! use tokio::sync::oneshot;
 //!# tokio_test::block_on(async {
-//! let email = "test@example.com".to_string();
 //! let api_key = "<api_key>".to_string();
 //!
 //! // Create an api instance


### PR DESCRIPTION
Simple docs cleanup, no code changes.

Just removed the `email` param from the docstrings / README to reflect the changes in the dehashed API, which were implemented here in 8903c2ab877f336f8759b60e3159f3c8c22625c8